### PR TITLE
Require OMPython>=3.5.2, rework CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           - { name: '3.10', python: '3.10', tox: py310 }
-          - { name: '3.12', python: '3.12', tox: py312 }
+          - { name: '3.11', python: '3.11', tox: py311 }
           - { name: 'min', python: '3.10', tox: min }
     steps:
       - name: "Set up OpenModelica Compiler"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,17 +5,6 @@ on:
     tags: [ "*" ]
   pull_request:
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - run: python -m pip install --upgrade pip wheel
-      - run: pip install tox
-      - run: tox -elint
   tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
@@ -63,8 +52,20 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+  # this duplicates pre-commit.ci, so only run it on tags
+  # it guarantees that linting is passing prior to a release
+  lint-pre-release:
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.0.0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install tox
+      - run: python -m tox -e lint
   release:
-    needs: [ lint, tests ]
+    needs: [ tests, lint-pre-release ]
     name: PyPI release
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-  skip: [pip-compile]
-
 repos:
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.3.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,10 @@
 repos:
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.4.2
   hooks:
-  - id: pyupgrade
-    args: [--py310-plus]
-- repo: https://github.com/psf/black
-  rev: 23.3.0
+    - id: ruff
+    - id: ruff-format
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.28.2
   hooks:
-  - id: black
-    language_version: python3
-- repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
-  hooks:
-  - id: flake8
-    additional_dependencies: [flake8-bugbear==23.1.14]
+    - id: check-github-workflows

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,25 @@
+fix = true
+show-fixes = true
+output-format = "full"
+
+[format]
+docstring-code-format = true
+
+[lint]
+ignore = []
+select = [
+  "B",  # flake8-bugbear
+  "E",  # pycodestyle error
+  "F",  # pyflakes
+  "I",  # isort
+  "UP", # pyupgrade
+  "W",  # pycodestyle warning
+]
+
+[lint.isort]
+section-order = ["future", "standard-library", "testing", "science", "corrai", "third-party", "first-party", "local-folder"]
+
+[lint.isort.sections]
+testing = ["pytest"]
+science = ["numpy", "pandas", "OMPython"]
+corrai = ["corrai"]

--- a/modelitool/combitabconvert.py
+++ b/modelitool/combitabconvert.py
@@ -1,4 +1,5 @@
 import datetime as dt
+
 import pandas as pd
 
 

--- a/modelitool/corrai_connector.py
+++ b/modelitool/corrai_connector.py
@@ -1,6 +1,8 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
+
 from corrai.base.parameter import Parameter
+
 from modelitool.simulate import OMModel
 
 

--- a/modelitool/simulate.py
+++ b/modelitool/simulate.py
@@ -3,12 +3,11 @@ import tempfile
 from pathlib import Path
 
 import pandas as pd
-from OMPython import ModelicaSystem
-from OMPython import OMCSessionZMQ
+from OMPython import ModelicaSystem, OMCSessionZMQ
+
 from corrai.base.model import Model
 
-from modelitool.combitabconvert import df_to_combitimetable
-from modelitool.combitabconvert import seconds_to_datetime
+from modelitool.combitabconvert import df_to_combitimetable, seconds_to_datetime
 
 
 class OMModel(Model):

--- a/modelitool/weather.py
+++ b/modelitool/weather.py
@@ -1,6 +1,9 @@
-import requests
 import json
+
 import pandas as pd
+
+import requests
+
 from .combitabconvert import get_dymo_time_index
 
 # TODO

--- a/requirements/install-min.txt
+++ b/requirements/install-min.txt
@@ -1,4 +1,4 @@
 pandas>=1.5.0
 numpy>=1.17.3
-OMPython>=3.4.0
+OMPython>=3.5.2
 corrai>=0.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203,B028
-
 [bumpversion]
 current_version = 0.1.0
 commit = True

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "pandas>=1.5.0",
         "numpy>=1.17.3",
-        "OMPython>=3.4.0",
+        "OMPython>=3.5.2",
         "corrai>=0.3.0",
     ],
     packages=find_packages(exclude=["tests*"]),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Modelitool"""
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Get the long description from the README file
 with open("README.md", encoding="utf-8") as f:

--- a/tests/test_combitabconvert.py
+++ b/tests/test_combitabconvert.py
@@ -1,12 +1,14 @@
-import pandas as pd
-
-from modelitool.combitabconvert import df_to_combitimetable
-from modelitool.combitabconvert import seconds_to_datetime
-from modelitool.combitabconvert import datetime_to_seconds
-
 from datetime import timedelta
 
 import pytest
+
+import pandas as pd
+
+from modelitool.combitabconvert import (
+    datetime_to_seconds,
+    df_to_combitimetable,
+    seconds_to_datetime,
+)
 
 
 class TestCombitabconvert:

--- a/tests/test_corrai_connector.py
+++ b/tests/test_corrai_connector.py
@@ -1,15 +1,16 @@
-import numpy as np
-import pandas as pd
 from pathlib import Path
 
 import pytest
 
-from sklearn.metrics import mean_squared_error, mean_absolute_error
-from modelitool.simulate import OMModel
+import numpy as np
+import pandas as pd
+
 from corrai.base.parameter import Parameter
 
-from modelitool.corrai_connector import ModelicaFunction
+from sklearn.metrics import mean_absolute_error, mean_squared_error
 
+from modelitool.corrai_connector import ModelicaFunction
+from modelitool.simulate import OMModel
 
 PACKAGE_DIR = Path(__file__).parent / "TestLib"
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-import numpy as np
+
 import pytest
 
-from modelitool.simulate import OMModel
-from modelitool.simulate import load_library, library_contents
-
-
+import numpy as np
 import pandas as pd
+
+from modelitool.simulate import OMModel, library_contents, load_library
 
 PACKAGE_DIR = Path(__file__).parent / "TestLib"
 
@@ -72,8 +71,8 @@ class TestSimulator:
         try:
             load_library(libpath)
             assert True
-        except ValueError:
-            raise AssertionError("library not loaded, failed test")
+        except ValueError as exc:
+            raise AssertionError("library not loaded, failed test") from exc
 
         library_contents(libpath)
         out, err = capfd.readouterr()

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,6 @@ deps =
     pre-commit
 skip_install = true
 commands =
-    pre-commit run pyupgrade --all-files --show-diff-on-failure
-    pre-commit run black --all-files --show-diff-on-failure
-    pre-commit run flake8 --all-files --show-diff-on-failure
+    pre-commit run ruff --all-files --show-diff-on-failure
+    pre-commit run ruff-format --all-files --show-diff-on-failure
+    pre-commit run check-github-workflows --all-files --show-diff-on-failure

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py310,py311,py312,min
+envlist = lint,py310,py311,min
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This forces the installation of latest OMPython revision, which includes fixes for Linux issues (see https://github.com/OpenModelica/OMPython/pull/214#issuecomment-2158827011).

Should be removed when next OMPython release ships.